### PR TITLE
Fix dynamic Azure app name in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,12 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       
       - name: Deploy Bicep Template
+        id: deploy_bicep
         uses: azure/arm-deploy@v2
         with:
           subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resourceGroupName: sensory-rg
+          resourceGroupLocation: centralus
           template: ./infra/main.bicep
           parameters: location=centralus
       
@@ -44,5 +46,5 @@ jobs:
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:
-          app-name: sensory-evaluation-quiz
+          app-name: ${{ steps.deploy_bicep.outputs.webAppName }}
           package: deploy.zip

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,3 +30,4 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
 }
 
 output webAppUrl string = 'https://${webApp.properties.defaultHostName}'
+output webAppName string = webApp.name


### PR DESCRIPTION
## Summary
- output web app name from Bicep template
- use Bicep output directly in deploy step
- ensure RG is created by specifying `resourceGroupLocation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868041bd56c832bb38c60a4dd7613e1